### PR TITLE
Check SHAs of PRs match what we expected

### DIFF
--- a/src/projects.ts
+++ b/src/projects.ts
@@ -148,7 +148,7 @@ export class Project {
 
         log.debug(`Getting changes in ${this.name} from ${fromVer} to ${toVer}`);
         const mergedPrs = await getMergedPrs(this.dir, fromVer, toVer);
-        log.debug("Found set of merged PRs: " + mergedPrs.join(', '));
+        log.debug("Found set of merged PRs: " + mergedPrs.map(pr => pr.PrNumber).join(', '));
         log.debug(`Fetching PR metadata from ${this.owner}/${this.repo}...`);
         const prInfo = await getPrInfo(this.owner, this.repo, mergedPrs);
 


### PR DESCRIPTION
and also fetch single remaining PRs individually rather than
paginating for a single PR.

Fixes https://github.com/matrix-org/allchange/issues/21