### PR TITLE
Filter out deduplicate and outdated issues

### DIFF
--- a/src/changes-test.ts
+++ b/src/changes-test.ts
@@ -236,3 +236,15 @@ test('Fixes parsed from issue URL', () => {
     }
 });
 
+test('Change reports deduplicated', () => {
+    const pr = mockPr();
+    pr.body = [
+        "Fixes #123",
+        "Fixes #123",
+    ].join("\n");
+
+    const change = changeFromPrInfo(pr);
+
+    expect(change.fixes.length).toEqual(1);
+    expect(change.fixes[0].number).toEqual(123);
+});

--- a/src/changes-test.ts
+++ b/src/changes-test.ts
@@ -248,3 +248,18 @@ test('Change reports deduplicated', () => {
     expect(change.fixes.length).toEqual(1);
     expect(change.fixes[0].number).toEqual(123);
 });
+
+test('Changelog preview filtered out', () => {
+    const pr = mockPr();
+    pr.body = [
+        "Fixes #123",
+        "<!-- CHANGELOG_PREVIEW_START -->",
+        "Fixes #456",
+        "<!-- CHANGELOG_PREVIEW_END -->",
+    ].join("\n");
+
+    const change = changeFromPrInfo(pr);
+
+    expect(change.fixes.length).toEqual(1);
+    expect(change.fixes[0].number).toEqual(123);
+});

--- a/src/changes.ts
+++ b/src/changes.ts
@@ -193,7 +193,7 @@ export function changeFromPrInfo(pr: PrInfo): IChange {
     let headline = null;
     const notesByProject = {};
     let matches: RegExpMatchArray;
-    const fixes = [] as IIssueID[];
+    const fixes = new Map<string, IIssueID>();
 
     if (pr.body) {
         for (const line of pr.body.split("\n")) {
@@ -210,23 +210,26 @@ export function changeFromPrInfo(pr: PrInfo): IChange {
                 // bafflingly, github's API doesn't give you issues fixed by this PR,
                 // so let's try to parse it ourselves (although of course this will only
                 // get ones in the PR body, not the comments...)
-                fixes.push({
+                const issue = {
                     owner: pr.base.repo.owner.name,
                     repo: pr.base.repo.name,
                     number: parseInt(matches[1]),
-                });
+                };
+                fixes.set(`${issue.owner}/${issue.repo}#${issue.number}`, issue);
             } else if (matches = line.match(OWNER_HASH_NUMBER_ISSUE_REGEXP)) {
-                fixes.push({
+                const issue = {
                     owner: matches[1],
                     repo: matches[2],
                     number: parseInt(matches[3]),
-                });
+                };
+                fixes.set(`${issue.owner}/${issue.repo}#${issue.number}`, issue);
             } else if (matches = line.match(ISSUE_URL_REGEXP)) {
-                fixes.push({
+                const issue = {
                     owner: matches[1],
                     repo: matches[2],
                     number: parseInt(matches[3]),
-                });
+                };
+                fixes.set(`${issue.owner}/${issue.repo}#${issue.number}`, issue);
             }
         }
     }
@@ -237,7 +240,7 @@ export function changeFromPrInfo(pr: PrInfo): IChange {
         notesByProject,
         headline,
         changeType,
-        fixes,
+        fixes: [...fixes.values()],
         breaking,
         security,
     };

--- a/src/changes.ts
+++ b/src/changes.ts
@@ -36,6 +36,8 @@ const ISSUE_URL_REGEXP =
 
 const MERGE_COMMIT_REGEX = /Merge pull request #(\d+) from (.*)/;
 
+const MAGIC_COMMENT_REGEXP = /<!-- CHANGELOG_PREVIEW_START -->(.*)<!-- CHANGELOG_PREVIEW_END -->/s;
+
 export enum ChangeType {
     FEATURE,
     BUGFIX,
@@ -196,7 +198,8 @@ export function changeFromPrInfo(pr: PrInfo): IChange {
     const fixes = new Map<string, IIssueID>();
 
     if (pr.body) {
-        for (const line of pr.body.split("\n")) {
+        const bodyMainContent = pr.body.replace(MAGIC_COMMENT_REGEXP, "");
+        for (const line of bodyMainContent.split("\n")) {
             const trimmed = line.trim();
             if (trimmed.toLowerCase().startsWith(NOTES_MAGIC_TEXT)) {
                 notes = trimmed.split(':', 2)[1].trim();


### PR DESCRIPTION
This filters out several causes of duplicate or outdated issues in the changelog output. This leads to a cleaner changelog, since it fixes the issue which seems to cause most entries to print their fixed issues twice currently.